### PR TITLE
💡 feat: 連接假後端，用 google sheet 當作當作 db

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5919,6 +5919,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jiti": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
+      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6478,6 +6489,246 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
+      "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-darwin-arm64": "1.30.1",
+        "lightningcss-darwin-x64": "1.30.1",
+        "lightningcss-freebsd-x64": "1.30.1",
+        "lightningcss-linux-arm-gnueabihf": "1.30.1",
+        "lightningcss-linux-arm64-gnu": "1.30.1",
+        "lightningcss-linux-arm64-musl": "1.30.1",
+        "lightningcss-linux-x64-gnu": "1.30.1",
+        "lightningcss-linux-x64-musl": "1.30.1",
+        "lightningcss-win32-arm64-msvc": "1.30.1",
+        "lightningcss-win32-x64-msvc": "1.30.1"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
+      "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
+      "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
+      "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
+      "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
+      "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
+      "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
+      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
+      "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
+      "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
+      "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/listr2": {
@@ -8843,6 +9094,15 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.12.tgz",
+      "integrity": "sha512-DzFtxOi+7NsFf7DBtI3BJsynR+0Yp6etH+nRPTbpWnS2pZBaSksv/JGctNwSWzbFjp0vxSqknaUylseZqMDGrA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/tar": {
       "version": "6.2.1",

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,3 @@
+.snack-success .mdc-snackbar__surface { background: #16a34a; color: #fff; }
+.snack-error   .mdc-snackbar__surface { background: #dc2626; color: #fff; }
+.snack-info    .mdc-snackbar__surface { background: #0ea5e9; color: #fff; }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ReactiveFormsModule } from '@angular/forms';
 import { AppRoutingModule } from './app-routing.module';
+import { HttpClientModule } from '@angular/common/http';
 
 import { AppComponent } from './app.component';
 import { LoginComponent } from './auth/login.component';
@@ -20,6 +21,7 @@ import { MatPaginatorModule } from '@angular/material/paginator';
     BrowserAnimationsModule,
     ReactiveFormsModule,
     AppRoutingModule,
+    HttpClientModule,
 
     AppComponent,
     LoginComponent,

--- a/src/app/article/article-form.component.html
+++ b/src/app/article/article-form.component.html
@@ -1,4 +1,10 @@
-<form [formGroup]="form" (ngSubmit)="onSubmit()">
+<div class="flex gap-x-2 items-center">
+  <button matIconButton (click)="onBack()">
+    <mat-icon>arrow_back</mat-icon>
+  </button>
+  <h2>新增文章</h2>
+</div>
+<form [formGroup]="form" (ngSubmit)="onSubmit()" [class.pointer-events-none]="isSubmitting">
   <mat-form-field appearance="outline">
     <mat-label>標題</mat-label>
     <input matInput formControlName="title" required />
@@ -21,9 +27,14 @@
   <mat-radio-group formControlName="status">
     <mat-radio-button value="draft">草稿</mat-radio-button>
     <mat-radio-button value="published">發佈</mat-radio-button>
+    <mat-radio-button value="unpublished">不發佈</mat-radio-button>
   </mat-radio-group>
 
-  <button mat-raised-button color="primary" type="submit">
-    {{ isEdit ? '更新文章' : '建立文章' }}
+  <button mat-raised-button color="primary" type="submit" [disabled]="form.invalid || isSubmitting">
+    <span *ngIf="!isSubmitting">{{ isEdit ? '更新文章' : '建立文章' }}</span>
+    <span *ngIf="isSubmitting" class="flex items-center gap-x-2">
+      <mat-progress-spinner diameter="18" mode="indeterminate"></mat-progress-spinner>
+      處理中...
+    </span>
   </button>
 </form>

--- a/src/app/article/article-form.component.scss
+++ b/src/app/article/article-form.component.scss
@@ -9,3 +9,15 @@ form {
 mat-form-field, mat-radio-group {
   width: 100%;
 }
+
+.flex {
+  display: flex;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.gap-x-2 {
+  gap: 8px;
+}

--- a/src/app/article/article-form.component.ts
+++ b/src/app/article/article-form.component.ts
@@ -1,19 +1,27 @@
 import { Component, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup, Validators, FormArray, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { finalize } from 'rxjs/operators';
 import { ArticleService } from './article.service';
 import { Article } from './article.model';
 import { CommonModule } from '@angular/common';
+import { GoogleSheetsService } from './google-sheets.service';
+// material
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { MatRadioModule } from '@angular/material/radio';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatIconModule } from '@angular/material/icon';
 
+// @Component 是 Angular 中的裝飾器，用來定義一個元件（Component）
 @Component({
+  // 元件在 HTML 中的名稱
   selector: 'app-article-form',
   templateUrl: './article-form.component.html',
   styleUrls: ['./article-form.component.scss'],
+  // 	Angular 14 以後的 Standalone Component 才有，用來直接引入需要的模組，不需註冊在 NgModule 裡
   imports: [
     CommonModule,
     ReactiveFormsModule,
@@ -21,19 +29,24 @@ import { MatRadioModule } from '@angular/material/radio';
     MatInputModule,
     MatCardModule,
     MatButtonModule,
-    MatRadioModule
+    MatRadioModule,
+    MatProgressSpinnerModule,
+    MatIconModule
   ]
 })
+
 export class ArticleFormComponent implements OnInit {
   form!: FormGroup;
   isEdit = false;
-  articleId?: number;
+  articleId?: string;
+  isSubmitting = false;
 
   constructor(
     private fb: FormBuilder,
     private route: ActivatedRoute,
     private router: Router,
-    private articleService: ArticleService
+    private articleService: ArticleService,
+    private gs: GoogleSheetsService
   ) {}
 
   ngOnInit(): void {
@@ -46,20 +59,21 @@ export class ArticleFormComponent implements OnInit {
 
     this.route.paramMap.subscribe(params => {
       const id = params.get('id');
-      if (id) {
-        const article = this.articleService.getById(+id);
-        if (article) {
-          this.isEdit = true;
-          this.articleId = article.id;
-          this.form.patchValue(article);
-        }
-      }
+      this.articleId = id ? id + '': undefined
+      // if (id) {
+      //   const article = this.articleService.getById(+id);
+      //   if (article) {
+      //     this.isEdit = true;
+      //     this.articleId = article.id;
+      //     this.form.patchValue(article);
+      //   }
+      // }
     });
   }
 
   onSubmit() {
     if (this.form.invalid) return;
-
+    this.isSubmitting = true;
     const tagsValue = this.form.value.tags;
     const tagsArray = typeof tagsValue === 'string'
       ? tagsValue.split(',').map(tag => tag.trim()).filter(tag => tag)
@@ -70,15 +84,26 @@ export class ArticleFormComponent implements OnInit {
       author: 'Admin',
       createdAt: new Date(),
       tags: tagsArray,
-      ...this.form.value
+      sheetName: 'article',
+      ...this.form.value,
+      status: this.form.value.status || 'draft'
     };
-
     if (this.isEdit) {
       this.articleService.update(article);
     } else {
-      this.articleService.create(article);
+      this.gs.addArticleViaAppsScript(article)
+      .pipe(finalize(() => this.isSubmitting = false))
+      .subscribe({
+        next: (res) => {
+          console.log('寫入成功', res);
+          this.router.navigate(['/article']);
+        },
+        error: (e) => console.error('寫入失敗', e),
+      });
     }
+  }
 
+  onBack() {
     this.router.navigate(['/article']);
   }
 }

--- a/src/app/article/article-list.component.html
+++ b/src/app/article/article-list.component.html
@@ -1,6 +1,9 @@
 <div class="list-header">
   <h2>文章列表</h2>
-  <button mat-raised-button color="primary" (click)="onCreate()">新增文章</button>
+  <button mat-raised-button color="primary" (click)="onCreate()">
+    <mat-icon>add</mat-icon>
+    新增文章
+  </button>
 </div>
 <mat-form-field appearance="outline" class="search-bar">
   <mat-label>Search</mat-label>
@@ -12,19 +15,21 @@
   <!-- Title Column -->
   <ng-container matColumnDef="title">
     <th mat-header-cell *matHeaderCellDef> Article </th>
-    <td mat-cell *matCellDef="let article"> {{article.title}} </td>
+    <td mat-cell *matCellDef="let article" class="max-w-xs">
+      <div class="truncate">{{ article.title }} </div>
+    </td>
   </ng-container>
 
   <!-- Author Column -->
   <ng-container matColumnDef="author">
     <th mat-header-cell *matHeaderCellDef> Author </th>
-    <td mat-cell *matCellDef="let article"> {{article.author}} </td>
+    <td mat-cell *matCellDef="let article"> {{ article.author }} </td>
   </ng-container>
 
   <!-- Created Date Column -->
   <ng-container matColumnDef="createdAt">
     <th mat-header-cell *matHeaderCellDef> Created At </th>
-    <td mat-cell *matCellDef="let article"> {{article.createdAt | date:'yyyy/MM/dd'}} </td>
+    <td mat-cell *matCellDef="let article"> {{ article.createdAt | date:'yyyy/MM/dd' }} </td>
   </ng-container>
 
   <!-- Actions Column -->
@@ -32,17 +37,25 @@
     <th mat-header-cell *matHeaderCellDef> Actions </th>
     <td mat-cell *matCellDef="let article">
       <button mat-button matButton="filled" color="primary" (click)="onEdit(article.id)">Edit</button>
-      <button mat-button matButton="tonal" (click)="onDelete(article.id)">Delete</button>
+      <button mat-button matButton="tonal" class="ml-2" (click)="onDelete(article)" [disabled]="article?.id === deletingId">
+        <span *ngIf="article?.id !== deletingId">Delete</span>
+        <span *ngIf="article?.id === deletingId" class="flex items-center gap-x-2">
+          <mat-progress-spinner diameter="18" mode="indeterminate"></mat-progress-spinner>
+        </span>
+      </button>
     </td>
   </ng-container>
 
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
 </table>
-
+<div *ngIf="!isTableLoading && dataSource.data?.length === 0" class="p-4 text-center text-gray-500">
+  目前沒有資料
+</div>
+<mat-spinner *ngIf="isTableLoading" diameter="50"></mat-spinner>
 <mat-paginator
   [length]="dataSource.data.length"
-  [pageSize]="5"
+  [pageSize]="10"
   showFirstLastButtons
   [pageSizeOptions]="[5, 10, 20]">
 </mat-paginator>

--- a/src/app/article/article-list.component.scss
+++ b/src/app/article/article-list.component.scss
@@ -24,3 +24,34 @@ mat-paginator {
   align-items: center;
   margin-bottom: 1rem;
 }
+
+.ml-2 {
+  margin-left: 8px;
+}
+
+mat-spinner {
+  margin: 20px auto;
+}
+
+.p-4 {
+  padding: 16px;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.text-gray-500 {
+  color: #6b7280;
+}
+
+.truncate {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.max-w-xs {
+  max-width: 460px;
+}

--- a/src/app/article/article-list.component.ts
+++ b/src/app/article/article-list.component.ts
@@ -2,13 +2,20 @@ import { Component, OnInit, ViewChild, AfterViewInit } from '@angular/core';
 import { CommonModule, DatePipe } from '@angular/common';
 import { ArticleService } from './article.service';
 import { Article } from './article.model';
+import { finalize } from 'rxjs/operators';
+
+import { Router } from '@angular/router';
+import { GoogleSheetsService } from './google-sheets.service';
+
+// material
 import { MatTableModule } from '@angular/material/table';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTableDataSource } from '@angular/material/table';
-import { Router } from '@angular/router';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'app-article-list',
@@ -19,7 +26,9 @@ import { Router } from '@angular/router';
     MatFormFieldModule,
     MatInputModule,
     MatButtonModule,
-    DatePipe
+    DatePipe,
+    MatProgressSpinnerModule,
+    MatIconModule
   ],
   templateUrl: './article-list.component.html',
   styleUrls: ['./article-list.component.scss']
@@ -28,29 +37,51 @@ import { Router } from '@angular/router';
 export class ArticleListComponent implements OnInit, AfterViewInit {
   dataSource = new MatTableDataSource<Article>();
   displayedColumns: string[] = ['title', 'author', 'createdAt', 'actions'];
+  isTableLoading = false
+  deletingId: string | number | null = null;
 
   @ViewChild(MatPaginator) paginator!: MatPaginator;
 
-  constructor(private articleService: ArticleService, private router: Router) {}
+  constructor(private articleService: ArticleService, private gs: GoogleSheetsService, private router: Router) {}
 
   ngOnInit(): void {
-    this.articleService.getAll().subscribe(data => {
-      this.dataSource.data = data;
-    });
+    this.isTableLoading = true;
+    this.gs.getSheetData('article')
+      .pipe(finalize(() => this.isTableLoading = false))
+      .subscribe((res: any) => this.dataSource.data = res)
   }
+
   ngAfterViewInit(): void {
-    this.dataSource.paginator = this.paginator;
+    this.dataSource.paginator = this.paginator
   }
 
   applyFilter(event: Event) {
-    const filterValue = (event.target as HTMLInputElement).value;
-    this.dataSource.filter = filterValue.trim().toLowerCase();
+    const filterValue = (event.target as HTMLInputElement).value
+    this.dataSource.filter = filterValue.trim().toLowerCase()
   }
 
-  onDelete(id: number) {
-    if (confirm('確定要刪除這篇文章嗎？')) {
-      this.articleService.delete(id);
-    }
+  onDelete(row: any) {
+    if (!confirm(`確定要刪除「${row.title}」嗎？`)) return
+    if (this.deletingId) return
+
+    this.deletingId = row.id
+    this.gs.deleteArticleViaAppsScript({ id: row.id, sheetName: 'article' })
+      .pipe(finalize(() => this.deletingId = null))
+      .subscribe({
+        next: (res) => {
+          if (res?.ok) {
+            this.dataSource.data = this.dataSource.data.filter((r: any) => r.id !== row.id);
+            // TODO: snackbar 提示成功
+          } else {
+            console.error('刪除失敗：', res);
+            // TODO: snackbar 提示失敗
+          }
+        },
+        error: (e) => {
+          console.error('刪除失敗：', e);
+          // TODO: snackbar 提示失敗
+        }
+      });
   }
 
   onEdit(id: number) {

--- a/src/app/article/article.model.ts
+++ b/src/app/article/article.model.ts
@@ -1,11 +1,12 @@
 // src/app/article/article.model.ts
 
 export interface Article {
-  id: number;
+  id: string | number;
   title: string;
   author: string;
-  createdAt: Date;
-  content: string;
-  tags: string[];
-  status: 'draft' | 'published';
+  createdAt: string; // e.g. '2025/08/21'
+  content?: string;
+  tags?: string[];
+  sheetName?: string;
+  status: 'draft' | 'published' | 'unpublished';
 }

--- a/src/app/article/article.service.ts
+++ b/src/app/article/article.service.ts
@@ -9,7 +9,7 @@ export class ArticleService {
       id: 1,
       title: 'Angular 教學入門',
       author: '小明',
-      createdAt: new Date('2025-08-01'),
+      createdAt: '2025-08-01',
       content: '這是一篇 Angular 教學文章。',
       tags: ['angular', 'frontend'],
       status: 'published'
@@ -18,7 +18,7 @@ export class ArticleService {
       id: 2,
       title: 'Angular 新手入門',
       author: '小華',
-      createdAt: new Date('2024-07-15'),
+      createdAt: '2024-07-15',
       content: 'Angular 新手入門怎麼那麼難',
       tags: ['angular', 'stream', 'rxjs'],
       status: 'draft'

--- a/src/app/article/google-sheets.service.ts
+++ b/src/app/article/google-sheets.service.ts
@@ -1,0 +1,76 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root',
+})
+
+export class GoogleSheetsService {
+  private spreadsheetId = '1tEs9mOYUA0SZuNorY6HS5AEQv-zCiO5VABfpwDA3OUE'; // 試算表 ID
+  private apiKey = 'AIzaSyCWlS3auqgd0wJaT8dTR2p_dXjA5kBkTjk'; // google API Key
+  private baseUrl = 'https://sheets.googleapis.com/v4/spreadsheets';
+  private appsScriptUrl = 'https://script.google.com/macros/s/AKfycbzwPYot9J9EbCdHrXH3X5MIVXmGfMgi0IUeiCgaemvxoHfZG0xa7akv3HLaSkT_f00K/exec'; // App Script URL
+  constructor(private http: HttpClient) {}
+
+  // 取得資料 (GET)
+  getSheetData(sheetName: string): Observable<any> {
+    const url = `${this.baseUrl}/${this.spreadsheetId}/values/${sheetName}?key=${this.apiKey}`;
+    return this.http.get<any>(url).pipe(
+      map(res => {
+        const values = res.values;
+        if (!values || values.length < 2) return [];
+
+        const headers = values[0];
+        const rows = values.slice(1);
+
+        return rows.map((row: string[]) => {
+          const obj: any = {};
+          headers.forEach((h: string, i: number) => {
+            obj[h] = row[i] ?? null; // 沒值就填 null
+          });
+          return obj;
+        });
+      })
+    );
+  }
+
+  addArticleViaAppsScript(payload: {
+    id: string | number;
+    title: string;
+    author: string;
+    createdAt: string; // e.g. '2025/08/21'
+    content?: string;
+    tags?: string[];
+    status?: string;
+    sheetName?: string;
+  }): Observable<any> {
+    const form = new FormData();
+    form.append('spreadsheetId', this.spreadsheetId);
+    form.append('sheetName', payload.sheetName ?? 'article');
+    form.append('id', String(payload.id));
+    form.append('title', payload.title);
+    form.append('author', payload.author);
+    form.append('createdAt', payload.createdAt);
+    form.append('content', payload.content ?? '');
+    form.append('tags', JSON.stringify(payload.tags));
+    form.append('status', payload.status ?? 'draft');
+
+    return this.http.post(this.appsScriptUrl, form);
+  }
+
+  deleteArticleViaAppsScript(payload: {
+    id: string | number;
+    sheetName?: string;
+  }): Observable<any> {
+    const form = new FormData();
+    form.append('action', 'delete');
+    form.append('spreadsheetId', this.spreadsheetId);
+    form.append('sheetName', payload.sheetName ?? 'article');
+    form.append('id', String(payload.id));
+
+    return this.http.post(this.appsScriptUrl, form);
+  }
+
+}


### PR DESCRIPTION
## Description
1. 增加資料可行性，故加上資料庫管理頁面資料。
2. 但不想花錢買DB管理，故選擇免費且直觀方案，串接 google sheet API 模擬資料庫存入取出。
3. 新增 `google-sheet.service` 處理上述方案。
4. 新增及取得資料時加上loading。